### PR TITLE
Fix windows path separator

### DIFF
--- a/lib/findNodeModulesPath.js
+++ b/lib/findNodeModulesPath.js
@@ -1,11 +1,12 @@
 var resolve = require('path').resolve;
+var separator = require('path').sep;
 var pathExists = require('./pathExists');
 
 module.exports = function findNodeModulesPath(baseDir) {
-  var dirsToCheck = baseDir.split('/');
+  var dirsToCheck = baseDir.split(separator);
   var currentPath;
   while (dirsToCheck.length) {
-    currentPath = resolve(dirsToCheck.join('/'), 'node_modules');
+    currentPath = resolve(dirsToCheck.join(separator), 'node_modules');
     if (pathExists(currentPath)) { return currentPath; }
     dirsToCheck.pop();
   }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "npm run lint && mocha test/**/*.test.js",
     "lint": "eslint lib test",
     "cover": "npm run istanbul && npm run coveralls",
-    "istanbul": "node istanbul cover _mocha --report lcovonly",
-    "coveralls": "cat ./coverage/lcov.info | coveralls.js"
+    "istanbul": "istanbul cover _mocha --report lcovonly",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Resolve modules from any directory.",
   "main": "lib/createBabelResolver.js",
   "scripts": {
-    "test": "npm run lint && node_modules/.bin/mocha test/**/*.test.js",
-    "lint": "./node_modules/.bin/eslint lib test",
+    "test": "npm run lint && mocha test/**/*.test.js",
+    "lint": "eslint lib test",
     "cover": "npm run istanbul && npm run coveralls",
-    "istanbul": "node node_modules/.bin/istanbul cover node_modules/.bin/_mocha --report lcovonly",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "istanbul": "node istanbul cover _mocha --report lcovonly",
+    "coveralls": "cat ./coverage/lcov.info | coveralls.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #2 
Uses the `sep` property of the node path module. In order to run the tests against this fix on windows, I modified the scripts in `package.json` by removing hardcoded `node_modules` paths (see https://github.com/npm/npm/issues/4040#issuecomment-27159695)
